### PR TITLE
Styling screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -74,8 +74,6 @@ function Root() {
 
       if (token && uid) {
         authCtx.authenticate(token, uid);
-        // userCtx.setUID(uid);
-        console.log('APP.JS');
         setAppIsReady(true);
       } else {
         setAppIsReady(true);

--- a/components/UI/FinishedClocking.js
+++ b/components/UI/FinishedClocking.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, Image, Modal, StyleSheet, Button } from 'react-native';
 import { ClockItColors } from '../../constants/styles';
 import { useNavigation } from '@react-navigation/native';
-const FinishedClocking = ({ modalVisible, displayText, onPress }) => {
+const FinishedClocking = ({ modalVisible, displayText, onPress, screenToNavigateTo }) => {
   const navigation = useNavigation();
   return (
     <Modal
@@ -11,7 +11,7 @@ const FinishedClocking = ({ modalVisible, displayText, onPress }) => {
       transparent={true}
       presentationStyle="overFullScreen"
       onDismiss={() => {
-        navigation.navigate('Home');
+        navigation.navigate(screenToNavigateTo);
       }}>
       <View style={styles.finishedContainer}>
         <View style={styles.modalTextIconContainer}>

--- a/components/UI/FinishedClocking.js
+++ b/components/UI/FinishedClocking.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, Image, Modal, StyleSheet, Button } from 'react-native';
 import { ClockItColors } from '../../constants/styles';
 import { useNavigation } from '@react-navigation/native';
-const FinishedClocking = ({ modalVisible, onPress }) => {
+const FinishedClocking = ({ modalVisible, displayText, onPress }) => {
   const navigation = useNavigation();
   return (
     <Modal
@@ -16,7 +16,7 @@ const FinishedClocking = ({ modalVisible, onPress }) => {
       <View style={styles.finishedContainer}>
         <View style={styles.modalTextIconContainer}>
           <Image style={styles.clockitIcon} source={require('../../assets/blueClockitIcon.png')} />
-          <Text style={styles.finishedText}> Woo! Clocked it!</Text>
+          <Text style={styles.finishedText}> {displayText}</Text>
           <Button title="Ok " onPress={onPress} />
         </View>
       </View>

--- a/components/auth/AuthContent.js
+++ b/components/auth/AuthContent.js
@@ -1,4 +1,3 @@
-import { useNavigation } from '@react-navigation/native';
 import { useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import FlatButton from '../buttons/FlatButton';
@@ -12,15 +11,6 @@ function AuthContent({ isLogin, onAuthenticate, resetLoginHandler }) {
     confirmEmail: false,
     confirmPassword: false,
   });
-  const navigation = useNavigation();
-  // function switchAuthModeHandler() {
-  //   // if (isLogin) {
-  //   //   navigation.replace('Signup');
-  //   // } else {
-  //   //   navigation.replace('Login');
-  //   // }
-  //   resetLoginHandler();
-  // }
 
   async function submitHandler(credentials) {
     let { email, confirmEmail, password, confirmPassword, userName } = credentials;

--- a/components/auth/AuthContent.js
+++ b/components/auth/AuthContent.js
@@ -1,13 +1,11 @@
+import { useNavigation } from '@react-navigation/native';
 import { useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import FlatButton from '../buttons/FlatButton';
-import AuthForm from './AuthForm';
-import { auth, db } from '../../firebase';
-import { getAuth, createUserWithEmailAndPassword } from 'firebase/auth';
 import ClockItLogo from '../UI/ClockItLogo';
+import AuthForm from './AuthForm';
 
-function AuthContent({ isLogin, onAuthenticate }) {
+function AuthContent({ isLogin, onAuthenticate, resetLoginHandler }) {
   const [credentialsInvalid, setCredentialsInvalid] = useState({
     email: false,
     password: false,
@@ -15,13 +13,14 @@ function AuthContent({ isLogin, onAuthenticate }) {
     confirmPassword: false,
   });
   const navigation = useNavigation();
-  function switchAuthModeHandler() {
-    if (isLogin) {
-      navigation.replace('Signup');
-    } else {
-      navigation.replace('Login');
-    }
-  }
+  // function switchAuthModeHandler() {
+  //   // if (isLogin) {
+  //   //   navigation.replace('Signup');
+  //   // } else {
+  //   //   navigation.replace('Login');
+  //   // }
+  //   resetLoginHandler();
+  // }
 
   async function submitHandler(credentials) {
     let { email, confirmEmail, password, confirmPassword, userName } = credentials;
@@ -60,7 +59,7 @@ function AuthContent({ isLogin, onAuthenticate }) {
         credentialsInvalid={credentialsInvalid}
       />
       <View style={styles.buttons}>
-        <FlatButton onPress={switchAuthModeHandler}>
+        <FlatButton onPress={resetLoginHandler}>
           {isLogin ? 'Create a new user' : 'Log in instead'}
         </FlatButton>
       </View>

--- a/components/stopWatch/stopwatch.js
+++ b/components/stopWatch/stopwatch.js
@@ -1,11 +1,11 @@
-import React, { useState, useRef } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import displayTime from '../../utils/padNumToTwo';
-import { ClockItColors } from '../../constants/styles';
+import React, { useRef, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import {
   FinishButton,
   ResetButton,
 } from '../../components/buttons/StopWatchButtons/TimeControlButtons';
+import { ClockItColors } from '../../constants/styles';
+import displayTime from '../../utils/padNumToTwo';
 
 const StopWatch = ({ addDataToFirebase, name }) => {
   const [time, setTime] = useState(0);
@@ -138,7 +138,7 @@ const styles = StyleSheet.create({
   timeDisplay: {
     fontSize: 60,
     flex: 1,
-    paddingLeft: 40,
+    paddingHorizontal: 50,
     fontFamily: 'Manrope_800ExtraBold',
     color: 'white',
   },

--- a/db/deleteClockitData.js
+++ b/db/deleteClockitData.js
@@ -1,4 +1,4 @@
-import { setDoc, updateDoc, doc } from 'firebase/firestore';
+import { doc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 
 export const deleteItemFromActivitiesList = async (userId, items, itemIdToRemove) => {

--- a/hooks/useFetchUserActivities.js
+++ b/hooks/useFetchUserActivities.js
@@ -1,6 +1,6 @@
-import { useState, useEffect, useContext, useRef } from 'react';
-import { db } from '../firebase';
 import { doc, getDoc } from 'firebase/firestore';
+import { useContext, useEffect, useState } from 'react';
+import { db } from '../firebase';
 import { UserContext } from '../store/User-Context';
 function useFetchUserActivities(userId) {
   const userCtx = useContext(UserContext);

--- a/hooks/useFetchUserActivities.js
+++ b/hooks/useFetchUserActivities.js
@@ -5,7 +5,6 @@ import { UserContext } from '../store/User-Context';
 function useFetchUserActivities(userId) {
   const userCtx = useContext(UserContext);
   const [isLoading, setIsLoading] = useState(true);
-  const weekOf = useRef(null);
 
   useEffect(() => {
     async function fetchActivities() {
@@ -13,9 +12,6 @@ function useFetchUserActivities(userId) {
         const activitiesOnLoad = await getDoc(doc(db, userId, 'activities'));
         if (activitiesOnLoad.exists()) {
           userCtx.dispatch({ type: 'INITIALIZE', payload: activitiesOnLoad.data().activities });
-          if (!weekOf.current) {
-            weekOf.current = activitiesOnLoad.data().weekOf;
-          }
         }
         setIsLoading(false);
       } catch (error) {
@@ -25,7 +21,7 @@ function useFetchUserActivities(userId) {
     fetchActivities();
     return () => {};
   }, [userId]);
-  return [isLoading, weekOf];
+  return isLoading;
 }
 
 export default useFetchUserActivities;

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -1,13 +1,12 @@
-import React, { useState, useEffect, useContext } from 'react';
-import { View, Text } from 'react-native';
+import React, { useContext } from 'react';
+
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 // context
 import { AuthContext } from '../store/Auth-Context';
 import UserContextProvider, { UserContext } from '../store/User-Context';
 // screens
-import LoginScreen from '../screens/Auth/LoginScreen';
-import SignupScreen from '../screens/Auth/SignupScreen';
+
 import SignUpLoginScreen from '../screens/Auth/SignUp-LoginScreen';
 import HomeScreen from '../screens/Home Screen/HomeScreen';
 import ClockItScreen from '../screens/Clock It Screen/clockItScreen';
@@ -17,8 +16,7 @@ import RenameActivityScreen from '../screens/RenameActivityScreen/RenameActivity
 import { ClockItColors } from '../constants/styles';
 // components
 import IconButton from '../components/buttons/IconButton';
-import { onAuthStateChanged, getAuth } from 'firebase/auth';
-import { deleteItemFromActivitiesList } from '../db/deleteClockitData';
+
 const Stack = createNativeStackNavigator();
 
 //

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -8,7 +8,7 @@ import UserContextProvider, { UserContext } from '../store/User-Context';
 // screens
 import LoginScreen from '../screens/Auth/LoginScreen';
 import SignupScreen from '../screens/Auth/SignupScreen';
-
+import SignUpLoginScreen from '../screens/Auth/SignUp-LoginScreen';
 import HomeScreen from '../screens/Home Screen/HomeScreen';
 import ClockItScreen from '../screens/Clock It Screen/clockItScreen';
 import RenameActivityScreen from '../screens/RenameActivityScreen/RenameActivityScreen';
@@ -29,8 +29,7 @@ function AuthStack() {
         headerShown: false,
         contentStyle: { backgroundColor: ClockItColors.blue },
       }}>
-      <Stack.Screen name="Login" component={LoginScreen} />
-      <Stack.Screen name="Signup" component={SignupScreen} />
+      <Stack.Screen name="SignupLogin" component={SignUpLoginScreen} />
     </Stack.Navigator>
   );
 }

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -59,7 +59,11 @@ const AuthenticatedStack = () => {
             ),
           }}
         />
-        <Stack.Screen name="RenameActivityScreen" component={RenameActivityScreen} />
+        <Stack.Screen
+          name="RenameActivityScreen"
+          options={{ headerTitle: '', headerBackTitle: 'Back' }}
+          component={RenameActivityScreen}
+        />
       </Stack.Navigator>
     </UserContextProvider>
   );

--- a/screens/Auth/LoginScreen.js
+++ b/screens/Auth/LoginScreen.js
@@ -7,8 +7,12 @@ import { AuthContext } from '../../store/Auth-Context';
 import { UserContext } from '../../store/User-Context';
 function LoginScreen() {
   const authCtx = useContext(AuthContext);
-  const userContext = useContext(UserContext);
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
+
+  const [isLogin, setIsLogin] = useState(false);
+  const [isLoggingIn, setIsLoggingIn] = useState(true);
+  const resetLoginHandler = () => {
+    setIsLogin(!isLogin);
+  };
   const loginHandler = async ({ email, password }) => {
     setIsLoggingIn(true);
     try {
@@ -22,7 +26,13 @@ function LoginScreen() {
     }
   };
   if (isLoggingIn) return <LoadingOverlay message="Logging you In" />;
-  return <AuthContent isLogin onAuthenticate={loginHandler} />;
+  return (
+    <AuthContent
+      isLogin={isLogin}
+      resetLoginHandler={resetLoginHandler}
+      onAuthenticate={loginHandler}
+    />
+  );
 }
 
 export default LoginScreen;

--- a/screens/Auth/SignUp-LoginScreen.js
+++ b/screens/Auth/SignUp-LoginScreen.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { StyleSheet, Text, View, Alert } from 'react-native';
+import { useContext, useState } from 'react';
+import AuthContent from '../../components/auth/AuthContent';
+import { AuthContext } from '../../store/Auth-Context';
+import { signUp, login } from '../../utils/Auth';
+import LoadingOverlay from '../../components/auth/ui/LoadingOverlay';
+
+const SignUpLoginScreen = () => {
+  const authCtx = useContext(AuthContext);
+  const [isLogin, setIsLogin] = useState(true);
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const resetLoginHandler = () => {
+    setIsLogin(!isLogin);
+  };
+
+  const loginHandler = async ({ email, password }) => {
+    setIsLoggingIn(true);
+    try {
+      let [token, uid] = await login(email, password);
+      if (token && uid) {
+        authCtx.authenticate(token, uid);
+      }
+    } catch (error) {
+      Alert.alert(`${error.message}`);
+      setIsLoggingIn(false);
+    }
+  };
+
+  const signUpHandler = async ({ email, password, userName }) => {
+    setIsAuthenticating(true);
+    try {
+      let [token, uid, expiryTime] = await signUp(email, password, userName);
+      if (token && uid && expiryTime) {
+        authCtx.authenticate(token, uid);
+      }
+    } catch (error) {
+      // handle Errors here , being thrown from /utils/auth
+      console.log(error.message, 'handle signup errors here.. email exists...etc');
+      setIsAuthenticating(false);
+      return;
+    }
+  };
+
+  if (isLoggingIn || isAuthenticating)
+    return <LoadingOverlay message={isLogin ? 'Logging you In' : 'Creating A User...'} />;
+  return (
+    <AuthContent
+      isLogin={isLogin}
+      resetLoginHandler={resetLoginHandler}
+      onAuthenticate={isLogin ? loginHandler : signUpHandler}
+    />
+  );
+};
+
+export default SignUpLoginScreen;
+
+const styles = StyleSheet.create({});

--- a/screens/Auth/SignupScreen.js
+++ b/screens/Auth/SignupScreen.js
@@ -1,16 +1,18 @@
-import { useState, useContext } from 'react';
+import { useContext, useState } from 'react';
 import AuthContent from '../../components/auth/AuthContent';
 import { AuthContext } from '../../store/Auth-Context';
-import { UserContext } from '../../store/User-Context';
 import { signUp } from '../../utils/Auth';
 
 import LoadingOverlay from '../../components/auth/ui/LoadingOverlay';
 
 function SignupScreen() {
   const authCtx = useContext(AuthContext);
-  const userContext = useContext(UserContext);
+  const [isLogin, setIsLogin] = useState(false);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
 
+  const resetLoginHandler = () => {
+    setIsLogin(!isLogin);
+  };
   const signUpHandler = async ({ email, password, userName }) => {
     setIsAuthenticating(true);
     try {
@@ -28,7 +30,13 @@ function SignupScreen() {
 
   if (isAuthenticating) return <LoadingOverlay message="Creating a User..." />;
 
-  return <AuthContent isLogin={false} onAuthenticate={signUpHandler} />;
+  return (
+    <AuthContent
+      isLogin={isLogin}
+      resetLoginHandler={resetLoginHandler}
+      onAuthenticate={signUpHandler}
+    />
+  );
 }
 
 export default SignupScreen;

--- a/screens/Clock It Screen/clockItScreen.js
+++ b/screens/Clock It Screen/clockItScreen.js
@@ -113,6 +113,7 @@ const ClockItScreen = ({ navigation, route }) => {
         modalVisible={isFinished}
         displayText="Woo! Clocked It!"
         onPress={dismissModalHandler}
+        screenToNavigateTo="Home"
       />
       <StopWatch addDataToFirebase={finishedHandler} name={userCtx.currentActivityItem.name} />
     </GradientView>

--- a/screens/Clock It Screen/clockItScreen.js
+++ b/screens/Clock It Screen/clockItScreen.js
@@ -109,7 +109,11 @@ const ClockItScreen = ({ navigation, route }) => {
         onRenameButtonPress={renameActivityHandler}
         onDeleteButtonPress={openConfirmDeleteModalHandler}
       />
-      <FinishedClocking modalVisible={isFinished} onPress={dismissModalHandler} />
+      <FinishedClocking
+        modalVisible={isFinished}
+        displayText="Woo! Clocked It!"
+        onPress={dismissModalHandler}
+      />
       <StopWatch addDataToFirebase={finishedHandler} name={userCtx.currentActivityItem.name} />
     </GradientView>
   );

--- a/screens/Home Screen/HomeScreen.js
+++ b/screens/Home Screen/HomeScreen.js
@@ -11,6 +11,8 @@ import SettingsCog from '../../components/UI/SettingsCog';
 import SettingsModal from '../../components/UI/SettingsModal';
 import WeekAndLogoDisplay from '../../components/UI/WeeKAndTitleDisplay';
 
+//Helpers
+import { getStartOfWeek } from '../../utils/DateTimeHelpers/DateTimeHelpers';
 // context
 import { AuthContext } from '../../store/Auth-Context';
 import { UserContext } from '../../store/User-Context.js';
@@ -25,7 +27,7 @@ const HomeScreen = ({ navigation, route }) => {
   const [settingsModalVisible, setSettingsModalVisible] = useState(false);
   const [addingActivities, setAddingActivities] = useState(false);
 
-  const [isLoading, weekOf] = useFetchUserActivities(userId);
+  const isLoading = useFetchUserActivities(userId);
 
   function addingActivitiesToHomeScreenHandler() {
     setAddingActivities(!addingActivities);
@@ -53,7 +55,7 @@ const HomeScreen = ({ navigation, route }) => {
 
   return (
     <GradientView style={styles.container}>
-      <WeekAndLogoDisplay weekOf={weekOf.current} />
+      <WeekAndLogoDisplay weekOf={getStartOfWeek()} />
       <ActivityInputContainer
         userId={userId}
         modalVisible={modalVisible}

--- a/screens/RenameActivityScreen/RenameActivityScreen.js
+++ b/screens/RenameActivityScreen/RenameActivityScreen.js
@@ -36,6 +36,7 @@ function RenameActivityScreen({ navigation, route }) {
         modalVisible={modalVisible}
         onPress={handleModalOpenClose}
         displayText={`Renamed ${originalName.current} to ${text}`}
+        screenToNavigateTo={{ name: 'Clockit', params: { userId } }}
       />
       <View style={styles.originalNameContainer}>
         <Text style={styles.heading}> Rename</Text>

--- a/screens/RenameActivityScreen/RenameActivityScreen.js
+++ b/screens/RenameActivityScreen/RenameActivityScreen.js
@@ -1,11 +1,11 @@
-import React, { useState, useContext, useRef } from 'react';
-import { View, Text, Modal, StyleSheet, TextInput, SafeAreaView } from 'react-native';
-import GradientView from '../../components/UI/BackgroundContainer';
+import React, { useContext, useRef, useState } from 'react';
+import { SafeAreaView, StyleSheet, Text, TextInput, View } from 'react-native';
 import ReusableUIButton from '../../components/buttons/ReusableUIButton';
+import GradientView from '../../components/UI/BackgroundContainer';
+import FinishedClocking from '../../components/UI/FinishedClocking';
+import { ClockItColors } from '../../constants/styles';
 import { updateUserActivities } from '../../db/writeClockitData';
 import { UserContext } from '../../store/User-Context';
-import { ClockItColors } from '../../constants/styles';
-import FinishedClocking from '../../components/UI/FinishedClocking';
 function RenameActivityScreen({ navigation, route }) {
   const userCtx = useContext(UserContext);
   const [modalVisible, setModalVisible] = useState(false);

--- a/screens/RenameActivityScreen/RenameActivityScreen.js
+++ b/screens/RenameActivityScreen/RenameActivityScreen.js
@@ -1,14 +1,17 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useRef } from 'react';
 import { View, Text, Modal, StyleSheet, TextInput, SafeAreaView } from 'react-native';
 import GradientView from '../../components/UI/BackgroundContainer';
 import ReusableUIButton from '../../components/buttons/ReusableUIButton';
 import { updateUserActivities } from '../../db/writeClockitData';
 import { UserContext } from '../../store/User-Context';
 import { ClockItColors } from '../../constants/styles';
+import FinishedClocking from '../../components/UI/FinishedClocking';
 function RenameActivityScreen({ navigation, route }) {
   const userCtx = useContext(UserContext);
+  const [modalVisible, setModalVisible] = useState(false);
   const [text, onChangeText] = useState('');
   const { userId } = route.params;
+  let originalName = useRef(userCtx.currentActivityItem.name);
   const renameActivityHandler = async () => {
     if (!text.trim().length) {
       return;
@@ -17,13 +20,27 @@ function RenameActivityScreen({ navigation, route }) {
       userCtx.currentActivityItem.name = text;
       userCtx.dispatch({ type: 'UPDATE', payload: userCtx.currentActivityItem });
       await updateUserActivities(userId, userCtx.activities);
+      handleModalOpenClose();
     } catch (error) {
       console.log('error Renaming your activity', error);
     }
   };
 
+  const handleModalOpenClose = () => {
+    setModalVisible(!modalVisible);
+  };
+
   return (
     <GradientView>
+      <FinishedClocking
+        modalVisible={modalVisible}
+        onPress={handleModalOpenClose}
+        displayText={`Renamed ${originalName.current} to ${text}`}
+      />
+      <View style={styles.originalNameContainer}>
+        <Text style={styles.heading}> Rename</Text>
+        <Text style={styles.originalName}>{originalName.current}</Text>
+      </View>
       <SafeAreaView style={styles.safeAreaWrapper}>
         <View style={styles.textInputContainer}>
           <TextInput placeholder="" style={styles.input} onChangeText={onChangeText} value={text} />
@@ -44,9 +61,17 @@ function RenameActivityScreen({ navigation, route }) {
 
 const styles = StyleSheet.create({
   screenContainer: {},
+  originalNameContainer: { flex: 0.5, justifyContent: 'flex-end', marginBottom: 60 },
+  heading: { fontFamily: 'Manrope_400Regular', color: 'white', fontSize: 32, textAlign: 'center' },
+  originalName: {
+    fontFamily: 'Manrope_700Bold',
+    color: 'white',
+    fontSize: 40,
+    textAlign: 'center',
+  },
   safeAreaWrapper: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     alignItems: 'center',
     width: '100%',
   },
@@ -54,6 +79,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flex: 0.1,
     alignItems: 'flex-start',
+    marginBottom: 40,
   },
   input: {
     color: 'black',
@@ -70,17 +96,22 @@ const styles = StyleSheet.create({
   buttonContainer: { flexDirection: 'row', flex: 0.2 },
   button: {
     backgroundColor: ClockItColors.buttonLime,
-    flex: 0.6,
+    flex: 0.7,
     borderRadius: 60,
-    height: 50,
-    maxHeight: 60,
+    height: 64,
+    maxHeight: 70,
     paddingVertical: 6,
     paddingHorizontal: 12,
     borderColor: 'white',
     borderWidth: 2,
-    backgroundColor: 'transparent',
   },
-  buttonTextContainer: {},
+  buttonTextContainer: { flex: 1, justifyContent: 'center', height: 64 },
+  buttonText: {
+    textAlign: 'center',
+    color: ClockItColors.dkBlue,
+    fontSize: 26,
+    fontFamily: 'Manrope_500Medium',
+  },
 });
 
 export default RenameActivityScreen;

--- a/utils/DateTimeHelpers/DateTimeHelpers.js
+++ b/utils/DateTimeHelpers/DateTimeHelpers.js
@@ -1,0 +1,13 @@
+export const findDay = () => {
+  let todaysDate = new Date();
+  let offSet = todaysDate.getTimezoneOffset();
+  todaysDate.setMinutes(todaysDate.getUTCMinutes() - offSet, 0, 0, 0);
+  //   todaysDate.setUTCHours(offSet);
+  return todaysDate;
+};
+
+export const getStartOfWeek = () => {
+  let today = findDay();
+  today.setDate(today.getDate() - today.getDay());
+  return today.toLocaleDateString();
+};


### PR DESCRIPTION
Changes: 

-Added some screen styling to the rename activities Screen, still needs final design review 
- consolidated login/ signup screen into one functional component. This avoids swapping screens out in favor of re-rendering props and makes for an arguably nicer user experience 
- Removed the ref for date/time that was being used as a display value. The ref would persist after logout and display when a new user was logging in. 

Notes: 
- Since the app displays data for the current week on the Home screen,  there needs to be a check run once upon the homescreen mount  ensuring that the fetched data is valid.  If it isnt, the week needs to be reset, and the previous weeks data needs to be stored in history. 
